### PR TITLE
Specify repository URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,10 @@
     "coverage": "istanbul cover _mocha"
   },
   "author": "Ian Patton <ian.patton@gmail.com> (http://github.com/niahmiah)",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/niahmiah/mongoose-uuid.git"
+  },
   "license": "ISC",
   "dependencies": {
     "bson": "~0.4",


### PR DESCRIPTION
I've added the repository field to the package.json. This allows sites like npmjs.com to link to the GitHub repo and makes `npm docs` work. Also, you won't get a warning message anymore every time you run `npm publish`.