### PR TITLE
update dependencies and remove node-uuid

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This also makes it easy for you to continue to work with UUIDs as strings in you
 ## How to use
 
 ```JavaScript
-var uuid = require('node-uuid');
+var uuidv4 = require('uuid/v4');
 var mongoose = require('mongoose');
 var Schema = mongoose.Schema;
 // Will add the UUID type to the Mongoose Schema types
@@ -27,12 +27,12 @@ require('mongoose-uuid2')(mongoose);
 var UUID = mongoose.Types.UUID;
 
 var ProductSchema = Schema({
-  _id: { type: UUID, default: uuid.v4 },
+  _id: { type: UUID, default: uuidv4 },
   name: String
 }, { id: false });
 
 var PhotoSchema = Schema({
-  _id: { type: UUID, default: uuid.v4 },
+  _id: { type: UUID, default: uuidv4 },
   filename: String,
   product: { type: UUID, ref: 'Product' }
 }, { id: false });

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 var mongoose = require('mongoose');
 var bson = require('bson');
 var util = require('util');
-var uuid = require('node-uuid');
+var uuidParse = require('uuid-parse');
 
 var Document = mongoose.Document;
 
@@ -11,7 +11,7 @@ function getter (binary){
   if(!binary) return undefined;
   if(!(binary instanceof mongoose.Types.Buffer.Binary)) return binary;
 
-  
+
   var len = binary.length();
 
   var b = binary.read(0,len);
@@ -67,7 +67,7 @@ SchemaUUID.prototype.cast = function (value, doc, init) {
     if (value instanceof mongoose.Types.Buffer.Binary) {
       return value;
     } else if (typeof value === 'string') {
-      var uuidBuffer = new mongoose.Types.Buffer(uuid.parse(value));
+      var uuidBuffer = new mongoose.Types.Buffer(uuidParse.parse(value));
       uuidBuffer.subtype(bson.Binary.SUBTYPE_UUID);
       return uuidBuffer.toObject();
     } else if (Buffer.isBuffer(value) || !util.isObject(value)) {
@@ -103,7 +103,7 @@ SchemaUUID.prototype.cast = function (value, doc, init) {
   var uuidBuffer;
 
   if (typeof value === 'string') {
-    uuidBuffer = new mongoose.Types.Buffer(uuid.parse(value));
+    uuidBuffer = new mongoose.Types.Buffer(uuidParse.parse(value));
     uuidBuffer.subtype(bson.Binary.SUBTYPE_UUID);
     return uuidBuffer.toObject();
   }

--- a/index.js
+++ b/index.js
@@ -7,123 +7,76 @@ var uuidParse = require('uuid-parse');
 
 var Document = mongoose.Document;
 
-function getter (binary){
-  if(!binary) return undefined;
-  if(!(binary instanceof mongoose.Types.Buffer.Binary)) return binary;
-
+function getter(binary) {
+  if (binary == null) return undefined;
+  if (!(binary instanceof mongoose.Types.Buffer.Binary)) return binary;
 
   var len = binary.length();
-
   var b = binary.read(0,len);
-
   var buf = new Buffer(len);
-
-  for (var i = 0; i < len; i++)
-    buf[i] = b[i];
-
   var hex = '';
 
-  for (var i = 0; i < len; i++)
-  {
-    var n = buf.readUInt8(i);
-    if (n < 16)
-      hex += '0'+n.toString(16);
-    else
-      hex += n.toString(16);
+  for (var i = 0; i < len; i++) {
+    buf[i] = b[i];
   }
 
-  var uuidStr = hex.substr(0, 8) + '-' + hex.substr(8, 4) + '-' + hex.substr(12, 4) + '-' + hex.substr(16, 4) + '-' + hex.substr(20, 12);
-  return uuidStr;
+  for (var i = 0; i < len; i++) {
+    var n = buf.readUInt8(i);
+
+    if (n < 16){
+      hex += '0' + n.toString(16);
+    } else {
+      hex += n.toString(16);
+    }
+  }
+
+  return hex.substr(0, 8) + '-' + hex.substr(8, 4) + '-' + hex.substr(12, 4) + '-' + hex.substr(16, 4) + '-' + hex.substr(20, 12);
 }
 
-function SchemaUUID(path, options){
+function SchemaUUID(path, options) {
   mongoose.SchemaTypes.Buffer.call(this, path, options);
+
   this.getters.push(getter);
 }
 
 util.inherits(SchemaUUID, mongoose.SchemaTypes.Buffer);
 
-
 SchemaUUID.schemaName = 'UUID';
 
-SchemaUUID.prototype.checkRequired = function (value) {
+SchemaUUID.prototype.checkRequired = function(value) {
   return value instanceof mongoose.Types.Buffer.Binary;
 };
 
-SchemaUUID.prototype.cast = function (value, doc, init) {
-  if (mongoose.SchemaType._isRef(this, value, doc, init)) {
-    // wait! we may need to cast this to a document
-
-    if (value === null || value === undefined) {
-      return value;
-    }
-
-    if (value instanceof Document) {
-      value.$__.wasPopulated = true;
-      return value;
-    }
-
-    // setting a populated path
-    if (value instanceof mongoose.Types.Buffer.Binary) {
-      return value;
-    } else if (typeof value === 'string') {
-      var uuidBuffer = new mongoose.Types.Buffer(uuidParse.parse(value));
-      uuidBuffer.subtype(bson.Binary.SUBTYPE_UUID);
-      return uuidBuffer.toObject();
-    } else if (Buffer.isBuffer(value) || !util.isObject(value)) {
-      throw new CastError('UUID', value, this.path);
-    }
-
-    // Handle the case where user directly sets a populated
-    // path to a plain object; cast to the Model used in
-    // the population query.
-    var path = doc.$__fullPath(this.path);
-    var owner = doc.ownerDocument ? doc.ownerDocument() : doc;
-    var pop = owner.populated(path, true);
-    var ret = value;
-    if (!doc.$__.populated ||
-        !doc.$__.populated[path] ||
-        !doc.$__.populated[path].options ||
-        !doc.$__.populated[path].options.options ||
-        !doc.$__.populated[path].options.options.lean) {
-      ret = new pop.options.model(value);
-      ret.$__.wasPopulated = true;
-    }
-
-    return ret;
-  }
-
-  if (value === null || value === undefined) {
-    return value;
-  }
-
-  if (value instanceof mongoose.Types.Buffer.Binary)
-    return value;
-
-  var uuidBuffer;
+SchemaUUID.prototype.cast = function(value, doc, init) {
+  if (value instanceof mongoose.Types.Buffer.Binary) return value;
 
   if (typeof value === 'string') {
-    uuidBuffer = new mongoose.Types.Buffer(uuidParse.parse(value));
+    var uuidBuffer = new mongoose.Types.Buffer(uuidParse.parse(value));
+
     uuidBuffer.subtype(bson.Binary.SUBTYPE_UUID);
+
     return uuidBuffer.toObject();
   }
 
-  throw new Error('Could not cast ' + value + ' to uuid.');
+  throw new Error('Could not cast ' + value + ' to UUID.');
 };
 
-SchemaUUID.prototype.castForQuery = function ($conditional, val) {
+SchemaUUID.prototype.castForQuery = function($conditional, val) {
   var handler;
+
   if (arguments.length === 2) {
     handler = this.$conditionalHandlers[$conditional];
-    if (!handler)
+
+    if (!handler) {
       throw new Error("Can't use " + $conditional + " with Buffer.");
+    }
+
     return handler.call(this, val);
-  } else {
-    val = $conditional;
-    return this.cast(val);
   }
+
+  return this.cast($conditional);
 };
 
-module.exports = function (mongoose){
+module.exports = function(mongoose) {
   mongoose.Types.UUID = mongoose.SchemaTypes.UUID = SchemaUUID;
 }

--- a/index.js
+++ b/index.js
@@ -68,7 +68,7 @@ SchemaUUID.prototype.castForQuery = function($conditional, val) {
     handler = this.$conditionalHandlers[$conditional];
 
     if (!handler) {
-      throw new Error("Can't use " + $conditional + " with Buffer.");
+      throw new Error("Can't use " + $conditional + " with UUID.");
     }
 
     return handler.call(this, val);

--- a/package-lock.json
+++ b/package-lock.json
@@ -117,6 +117,12 @@
         "concat-map": "0.0.1"
       }
     },
+    "browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
+    },
     "bson": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/bson/-/bson-3.0.2.tgz",
@@ -147,40 +153,24 @@
       }
     },
     "chai": {
-      "version": "3.5.0",
-      "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/chai/-/chai-3.5.0.tgz",
-      "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.1.2.tgz",
+      "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
       "dev": true,
       "requires": {
         "assertion-error": "1.1.0",
-        "deep-eql": "0.1.3",
-        "type-detect": "1.0.0"
-      },
-      "dependencies": {
-        "deep-eql": {
-          "version": "0.1.3",
-          "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/deep-eql/-/deep-eql-0.1.3.tgz",
-          "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
-          "dev": true,
-          "requires": {
-            "type-detect": "0.1.1"
-          },
-          "dependencies": {
-            "type-detect": {
-              "version": "0.1.1",
-              "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/type-detect/-/type-detect-0.1.1.tgz",
-              "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
-              "dev": true
-            }
-          }
-        },
-        "type-detect": {
-          "version": "1.0.0",
-          "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/type-detect/-/type-detect-1.0.0.tgz",
-          "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
-          "dev": true
-        }
+        "check-error": "1.0.2",
+        "deep-eql": "3.0.1",
+        "get-func-name": "2.0.0",
+        "pathval": "1.1.0",
+        "type-detect": "4.0.8"
       }
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "dev": true
     },
     "cliui": {
       "version": "2.1.0",
@@ -207,6 +197,12 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "dev": true
+    },
+    "commander": {
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
       "dev": true
     },
     "concat-map": {
@@ -267,6 +263,15 @@
       "dev": true,
       "optional": true
     },
+    "deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -279,6 +284,12 @@
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
     },
+    "diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true
+    },
     "ecc-jsbn": {
       "version": "0.1.1",
       "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
@@ -288,6 +299,12 @@
       "requires": {
         "jsbn": "0.1.1"
       }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
     },
     "escodegen": {
       "version": "1.8.1",
@@ -372,6 +389,18 @@
         }
       }
     },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "dev": true
+    },
     "getpass": {
       "version": "0.1.7",
       "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/getpass/-/getpass-0.1.7.tgz",
@@ -451,6 +480,12 @@
       "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
       "dev": true
     },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
+    },
     "http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
@@ -528,30 +563,6 @@
           "version": "1.5.2",
           "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-          "dev": true
-        }
-      }
-    },
-    "jade": {
-      "version": "0.26.3",
-      "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/jade/-/jade-0.26.3.tgz",
-      "integrity": "sha1-jxDXl32NefL2/4YqgbBRPMslaGw=",
-      "dev": true,
-      "requires": {
-        "commander": "0.6.1",
-        "mkdirp": "0.3.0"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "0.6.1",
-          "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/commander/-/commander-0.6.1.tgz",
-          "integrity": "sha1-+mihT2qUXVTbvlDYzbMyDp47GgY=",
-          "dev": true
-        },
-        "mkdirp": {
-          "version": "0.3.0",
-          "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/mkdirp/-/mkdirp-0.3.0.tgz",
-          "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=",
           "dev": true
         }
       }
@@ -664,12 +675,6 @@
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
       "dev": true
     },
-    "lru-cache": {
-      "version": "2.7.3",
-      "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/lru-cache/-/lru-cache-2.7.3.tgz",
-      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
-      "dev": true
-    },
     "mime-db": {
       "version": "1.30.0",
       "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/mime-db/-/mime-db-1.30.0.tgz",
@@ -718,87 +723,52 @@
       }
     },
     "mocha": {
-      "version": "2.5.3",
-      "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/mocha/-/mocha-2.5.3.tgz",
-      "integrity": "sha1-FhvlvetJZ3HrmzV0UFC2IrWu/Fg=",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
+      "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
       "dev": true,
       "requires": {
-        "commander": "2.3.0",
-        "debug": "2.2.0",
-        "diff": "1.4.0",
-        "escape-string-regexp": "1.0.2",
-        "glob": "3.2.11",
-        "growl": "1.9.2",
-        "jade": "0.26.3",
+        "browser-stdout": "1.3.1",
+        "commander": "2.15.1",
+        "debug": "3.1.0",
+        "diff": "3.5.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
+        "growl": "1.10.5",
+        "he": "1.1.1",
+        "minimatch": "3.0.4",
         "mkdirp": "0.5.1",
-        "supports-color": "1.2.0",
-        "to-iso-string": "0.0.2"
+        "supports-color": "5.4.0"
       },
       "dependencies": {
-        "commander": {
-          "version": "2.3.0",
-          "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/commander/-/commander-2.3.0.tgz",
-          "integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM=",
-          "dev": true
-        },
-        "debug": {
-          "version": "2.2.0",
-          "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.1"
-          }
-        },
-        "diff": {
-          "version": "1.4.0",
-          "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/diff/-/diff-1.4.0.tgz",
-          "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
-          "dev": true
-        },
-        "escape-string-regexp": {
-          "version": "1.0.2",
-          "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
-          "integrity": "sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE=",
-          "dev": true
-        },
         "glob": {
-          "version": "3.2.11",
-          "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/glob/-/glob-3.2.11.tgz",
-          "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
             "inherits": "2.0.3",
-            "minimatch": "0.3.0"
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
-        "growl": {
-          "version": "1.9.2",
-          "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/growl/-/growl-1.9.2.tgz",
-          "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
-          "dev": true
-        },
-        "minimatch": {
-          "version": "0.3.0",
-          "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/minimatch/-/minimatch-0.3.0.tgz",
-          "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
-          "dev": true,
-          "requires": {
-            "lru-cache": "2.7.3",
-            "sigmund": "1.0.1"
-          }
-        },
-        "ms": {
-          "version": "0.7.1",
-          "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/ms/-/ms-0.7.1.tgz",
-          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
           "dev": true
         },
         "supports-color": {
-          "version": "1.2.0",
-          "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/supports-color/-/supports-color-1.2.0.tgz",
-          "integrity": "sha1-/x7R5hFp0Gs88tWI4YixjYhH4X4=",
-          "dev": true
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
         }
       }
     },
@@ -952,6 +922,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "pathval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
       "dev": true
     },
     "performance-now": {
@@ -1118,12 +1094,6 @@
       "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/semver/-/semver-5.5.0.tgz",
       "integrity": "sha1-3Eu8emyp2Rbe5dQ1FvAJK1j3uKs="
     },
-    "sigmund": {
-      "version": "1.0.1",
-      "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/sigmund/-/sigmund-1.0.1.tgz",
-      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
-      "dev": true
-    },
     "sliced": {
       "version": "1.0.1",
       "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/sliced/-/sliced-1.0.1.tgz",
@@ -1170,12 +1140,6 @@
         "has-flag": "1.0.0"
       }
     },
-    "to-iso-string": {
-      "version": "0.0.2",
-      "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/to-iso-string/-/to-iso-string-0.0.2.tgz",
-      "integrity": "sha1-TcGeZk38y+Jb2NtQiwDG2hWCVdE=",
-      "dev": true
-    },
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -1200,6 +1164,12 @@
       "requires": {
         "prelude-ls": "1.1.2"
       }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "uglify-js": {
       "version": "2.8.29",

--- a/package-lock.json
+++ b/package-lock.json
@@ -118,9 +118,9 @@
       }
     },
     "bson": {
-      "version": "1.0.4",
-      "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/bson/-/bson-1.0.4.tgz",
-      "integrity": "sha1-k8ENOeqltYQVy8QFLz5T5WKwtyw="
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-3.0.2.tgz",
+      "integrity": "sha512-HrDzr7y/ZkgyEVancPVDmfbaD8j81GzSNr6h6yUd/yZfavkrlrqI8aUZMCHrhyMoCW2/I+vEJDat1xDWRwVR6A=="
     },
     "camelcase": {
       "version": "1.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "mongoose-uuid2",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "abbrev": {
       "version": "1.0.9",
-      "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/abbrev/-/abbrev-1.0.9.tgz",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
       "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
       "dev": true
     },
     "align-text": {
       "version": "0.1.4",
-      "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/align-text/-/align-text-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
       "requires": {
@@ -23,7 +23,7 @@
     },
     "amdefine": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/amdefine/-/amdefine-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
       "dev": true
     },
@@ -88,7 +88,7 @@
     },
     "balanced-match": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/balanced-match/-/balanced-match-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
@@ -108,9 +108,9 @@
       "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw="
     },
     "brace-expansion": {
-      "version": "1.1.8",
-      "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/brace-expansion/-/brace-expansion-1.1.8.tgz",
-      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
         "balanced-match": "1.0.0",
@@ -124,14 +124,14 @@
     },
     "camelcase": {
       "version": "1.2.1",
-      "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/camelcase/-/camelcase-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
       "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
       "dev": true,
       "optional": true
     },
     "center-align": {
       "version": "0.1.3",
-      "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/center-align/-/center-align-0.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
       "dev": true,
       "optional": true,
@@ -199,7 +199,7 @@
     },
     "cliui": {
       "version": "2.1.0",
-      "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/cliui/-/cliui-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
       "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
       "dev": true,
       "optional": true,
@@ -211,7 +211,7 @@
       "dependencies": {
         "wordwrap": {
           "version": "0.0.2",
-          "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/wordwrap/-/wordwrap-0.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
           "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
           "dev": true,
           "optional": true
@@ -235,7 +235,7 @@
     },
     "concat-map": {
       "version": "0.0.1",
-      "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/concat-map/-/concat-map-0.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
@@ -393,7 +393,7 @@
             "stringstream": "0.0.5",
             "tough-cookie": "2.3.3",
             "tunnel-agent": "0.4.3",
-            "uuid": "3.2.1"
+            "uuid": "3.3.2"
           }
         },
         "sntp": {
@@ -432,14 +432,14 @@
     },
     "decamelize": {
       "version": "1.2.0",
-      "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/decamelize/-/decamelize-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true,
       "optional": true
     },
     "deep-is": {
       "version": "0.1.3",
-      "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/deep-is/-/deep-is-0.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
@@ -465,21 +465,34 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
+    "escodegen": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
+      "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
+      "dev": true,
+      "requires": {
+        "esprima": "2.7.3",
+        "estraverse": "1.9.3",
+        "esutils": "2.0.2",
+        "optionator": "0.8.2",
+        "source-map": "0.2.0"
+      }
+    },
     "esprima": {
-      "version": "4.0.0",
-      "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/esprima/-/esprima-4.0.0.tgz",
-      "integrity": "sha1-RJnt3NERDgshi6zy+n9/WfVcqAQ=",
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+      "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
       "dev": true
     },
     "estraverse": {
       "version": "1.9.3",
-      "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/estraverse/-/estraverse-1.9.3.tgz",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
       "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=",
       "dev": true
     },
     "esutils": {
       "version": "2.0.2",
-      "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/esutils/-/esutils-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
@@ -495,26 +508,11 @@
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
       "dev": true
     },
-    "fileset": {
-      "version": "0.2.1",
-      "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/fileset/-/fileset-0.2.1.tgz",
-      "integrity": "sha1-WI74lzxmI7KnbfRlEFaWuWqsgGc=",
-      "dev": true,
-      "requires": {
-        "glob": "5.0.15",
-        "minimatch": "2.0.10"
-      },
-      "dependencies": {
-        "minimatch": {
-          "version": "2.0.10",
-          "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/minimatch/-/minimatch-2.0.10.tgz",
-          "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "1.1.8"
-          }
-        }
-      }
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -548,7 +546,7 @@
     },
     "glob": {
       "version": "5.0.15",
-      "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/glob/-/glob-5.0.15.tgz",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
       "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
       "dev": true,
       "requires": {
@@ -561,7 +559,7 @@
     },
     "handlebars": {
       "version": "4.0.11",
-      "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/handlebars/-/handlebars-4.0.11.tgz",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
       "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
       "dev": true,
       "requires": {
@@ -573,13 +571,13 @@
       "dependencies": {
         "async": {
           "version": "1.5.2",
-          "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/async/-/async-1.5.2.tgz",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
           "dev": true
         },
         "source-map": {
           "version": "0.4.4",
-          "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/source-map/-/source-map-0.4.4.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true,
           "requires": {
@@ -599,13 +597,13 @@
     },
     "has-flag": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/has-flag/-/has-flag-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
       "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
       "dev": true
     },
     "inflight": {
       "version": "1.0.6",
-      "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/inflight/-/inflight-1.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
@@ -621,8 +619,8 @@
     },
     "is-buffer": {
       "version": "1.1.6",
-      "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "dev": true
     },
     "is-my-json-valid": {
@@ -651,7 +649,7 @@
     },
     "isexe": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/isexe/-/isexe-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
@@ -662,97 +660,32 @@
       "dev": true
     },
     "istanbul": {
-      "version": "0.3.22",
-      "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/istanbul/-/istanbul-0.3.22.tgz",
-      "integrity": "sha1-PhZNhQIf4ZyYXR8OfvDD4i0BLrY=",
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.5.tgz",
+      "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
       "dev": true,
       "requires": {
         "abbrev": "1.0.9",
         "async": "1.5.2",
-        "escodegen": "1.7.1",
-        "esprima": "2.5.0",
-        "fileset": "0.2.1",
+        "escodegen": "1.8.1",
+        "esprima": "2.7.3",
+        "glob": "5.0.15",
         "handlebars": "4.0.11",
-        "js-yaml": "3.10.0",
+        "js-yaml": "3.12.0",
         "mkdirp": "0.5.1",
         "nopt": "3.0.6",
         "once": "1.4.0",
         "resolve": "1.1.7",
         "supports-color": "3.2.3",
-        "which": "1.3.0",
+        "which": "1.3.1",
         "wordwrap": "1.0.0"
       },
       "dependencies": {
         "async": {
           "version": "1.5.2",
-          "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/async/-/async-1.5.2.tgz",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
           "dev": true
-        },
-        "escodegen": {
-          "version": "1.7.1",
-          "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/escodegen/-/escodegen-1.7.1.tgz",
-          "integrity": "sha1-MOz89mypjcZ80v0WKr626vqM5vw=",
-          "dev": true,
-          "requires": {
-            "esprima": "1.2.5",
-            "estraverse": "1.9.3",
-            "esutils": "2.0.2",
-            "optionator": "0.5.0",
-            "source-map": "0.2.0"
-          },
-          "dependencies": {
-            "esprima": {
-              "version": "1.2.5",
-              "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/esprima/-/esprima-1.2.5.tgz",
-              "integrity": "sha1-CZNQL+r2aBODJXVvMPmlH+7sEek=",
-              "dev": true
-            }
-          }
-        },
-        "esprima": {
-          "version": "2.5.0",
-          "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/esprima/-/esprima-2.5.0.tgz",
-          "integrity": "sha1-84ekb9NEwbGjm6+MIL+0O20AWMw=",
-          "dev": true
-        },
-        "fast-levenshtein": {
-          "version": "1.0.7",
-          "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz",
-          "integrity": "sha1-AXjc3uAjuSkFGTrwlZ6KdjnP3Lk=",
-          "dev": true
-        },
-        "levn": {
-          "version": "0.2.5",
-          "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/levn/-/levn-0.2.5.tgz",
-          "integrity": "sha1-uo0znQykphDjo/FFucr0iAcVUFQ=",
-          "dev": true,
-          "requires": {
-            "prelude-ls": "1.1.2",
-            "type-check": "0.3.2"
-          }
-        },
-        "optionator": {
-          "version": "0.5.0",
-          "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/optionator/-/optionator-0.5.0.tgz",
-          "integrity": "sha1-t1qJlaLUF98ltuTjhi9QqohlE2g=",
-          "dev": true,
-          "requires": {
-            "deep-is": "0.1.3",
-            "fast-levenshtein": "1.0.7",
-            "levn": "0.2.5",
-            "prelude-ls": "1.1.2",
-            "type-check": "0.3.2",
-            "wordwrap": "0.0.3"
-          },
-          "dependencies": {
-            "wordwrap": {
-              "version": "0.0.3",
-              "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/wordwrap/-/wordwrap-0.0.3.tgz",
-              "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
-              "dev": true
-            }
-          }
         }
       }
     },
@@ -781,13 +714,21 @@
       }
     },
     "js-yaml": {
-      "version": "3.10.0",
-      "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/js-yaml/-/js-yaml-3.10.0.tgz",
-      "integrity": "sha1-LnhEFka9RoLpY/IrbpKCPDCcYtw=",
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
+      "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
       "dev": true,
       "requires": {
         "argparse": "1.0.9",
-        "esprima": "4.0.0"
+        "esprima": "4.0.1"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+          "dev": true
+        }
       }
     },
     "jsbn": {
@@ -834,7 +775,7 @@
     },
     "kind-of": {
       "version": "3.2.2",
-      "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/kind-of/-/kind-of-3.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
       "requires": {
@@ -843,7 +784,7 @@
     },
     "lazy-cache": {
       "version": "1.0.4",
-      "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/lazy-cache/-/lazy-cache-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
       "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
       "dev": true,
       "optional": true
@@ -853,6 +794,16 @@
       "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/lcov-parse/-/lcov-parse-0.0.10.tgz",
       "integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM=",
       "dev": true
+    },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
+      }
     },
     "lodash": {
       "version": "4.17.5",
@@ -872,7 +823,7 @@
     },
     "longest": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/longest/-/longest-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
       "dev": true
     },
@@ -899,11 +850,11 @@
     },
     "minimatch": {
       "version": "3.0.4",
-      "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.8"
+        "brace-expansion": "1.1.11"
       }
     },
     "minimist": {
@@ -1104,14 +1055,9 @@
       "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
-    "node-uuid": {
-      "version": "1.4.8",
-      "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/node-uuid/-/node-uuid-1.4.8.tgz",
-      "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
-    },
     "nopt": {
       "version": "3.0.6",
-      "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/nopt/-/nopt-3.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
       "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
       "dev": true,
       "requires": {
@@ -1126,7 +1072,7 @@
     },
     "once": {
       "version": "1.4.0",
-      "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/once/-/once-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
@@ -1135,7 +1081,7 @@
     },
     "optimist": {
       "version": "0.6.1",
-      "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/optimist/-/optimist-0.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "requires": {
@@ -1145,21 +1091,35 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.10",
-          "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/minimist/-/minimist-0.0.10.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
           "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
           "dev": true
         },
         "wordwrap": {
           "version": "0.0.3",
-          "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/wordwrap/-/wordwrap-0.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
           "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
           "dev": true
         }
       }
     },
+    "optionator": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "dev": true,
+      "requires": {
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "2.0.6",
+        "levn": "0.3.0",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "1.0.0"
+      }
+    },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
@@ -1180,7 +1140,7 @@
     },
     "prelude-ls": {
       "version": "1.1.2",
-      "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
@@ -1197,7 +1157,7 @@
     },
     "repeat-string": {
       "version": "1.6.1",
-      "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/repeat-string/-/repeat-string-1.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
       "dev": true
     },
@@ -1212,7 +1172,7 @@
     },
     "resolve": {
       "version": "1.1.7",
-      "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/resolve/-/resolve-1.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
       "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
       "dev": true
     },
@@ -1223,7 +1183,7 @@
     },
     "right-align": {
       "version": "0.1.3",
-      "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/right-align/-/right-align-0.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
       "dev": true,
       "optional": true,
@@ -1249,7 +1209,7 @@
     },
     "source-map": {
       "version": "0.2.0",
-      "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/source-map/-/source-map-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
       "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
       "dev": true,
       "optional": true,
@@ -1296,7 +1256,7 @@
     },
     "supports-color": {
       "version": "3.2.3",
-      "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/supports-color/-/supports-color-3.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
       "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
       "dev": true,
       "requires": {
@@ -1327,7 +1287,7 @@
     },
     "type-check": {
       "version": "0.3.2",
-      "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/type-check/-/type-check-0.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
@@ -1336,7 +1296,7 @@
     },
     "uglify-js": {
       "version": "2.8.29",
-      "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/uglify-js/-/uglify-js-2.8.29.tgz",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
       "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
       "dev": true,
       "optional": true,
@@ -1348,7 +1308,7 @@
       "dependencies": {
         "source-map": {
           "version": "0.5.7",
-          "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true,
           "optional": true
@@ -1357,16 +1317,21 @@
     },
     "uglify-to-browserify": {
       "version": "1.0.2",
-      "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
       "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
       "dev": true,
       "optional": true
     },
     "uuid": {
-      "version": "3.2.1",
-      "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/uuid/-/uuid-3.2.1.tgz",
-      "integrity": "sha1-EsUou51Y0LkmXZovbw/ovhf/HxQ=",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
       "dev": true
+    },
+    "uuid-parse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/uuid-parse/-/uuid-parse-1.0.0.tgz",
+      "integrity": "sha1-9GV3F2JLDkuIrzb5jYlYmlu+5Wk="
     },
     "verror": {
       "version": "1.10.0",
@@ -1380,9 +1345,9 @@
       }
     },
     "which": {
-      "version": "1.3.0",
-      "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/which/-/which-1.3.0.tgz",
-      "integrity": "sha1-/wS9/AEO5UfXgL7DjhrBwnd9JTo=",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "dev": true,
       "requires": {
         "isexe": "2.0.0"
@@ -1390,20 +1355,20 @@
     },
     "window-size": {
       "version": "0.1.0",
-      "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/window-size/-/window-size-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
       "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
       "dev": true,
       "optional": true
     },
     "wordwrap": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/wordwrap/-/wordwrap-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
       "dev": true
     },
     "wrappy": {
       "version": "1.0.2",
-      "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/wrappy/-/wrappy-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     },
@@ -1415,7 +1380,7 @@
     },
     "yargs": {
       "version": "3.10.0",
-      "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/yargs/-/yargs-3.10.0.tgz",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
       "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
       "dev": true,
       "optional": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,18 @@
       "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
       "dev": true
     },
+    "ajv": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+      "dev": true,
+      "requires": {
+        "co": "4.6.0",
+        "fast-deep-equal": "1.1.0",
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.3.1"
+      }
+    },
     "align-text": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
@@ -25,18 +37,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-      "dev": true
-    },
-    "ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-      "dev": true
-    },
-    "ansi-styles": {
-      "version": "2.2.1",
-      "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
       "dev": true
     },
     "argparse": {
@@ -80,10 +80,10 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
     },
-    "aws4": {
-      "version": "1.6.0",
-      "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/aws4/-/aws4-1.6.0.tgz",
-      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
       "dev": true
     },
     "balanced-match": {
@@ -128,6 +128,12 @@
       "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
       "dev": true,
       "optional": true
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+      "dev": true
     },
     "center-align": {
       "version": "0.1.3",
@@ -176,27 +182,6 @@
         }
       }
     },
-    "chalk": {
-      "version": "1.1.3",
-      "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-      "dev": true,
-      "requires": {
-        "ansi-styles": "2.2.1",
-        "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
-      },
-      "dependencies": {
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        }
-      }
-    },
     "cliui": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
@@ -218,19 +203,10 @@
         }
       }
     },
-    "combined-stream": {
-      "version": "1.0.5",
-      "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/combined-stream/-/combined-stream-1.0.5.tgz",
-      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-      "dev": true,
-      "requires": {
-        "delayed-stream": "1.0.0"
-      }
-    },
-    "commander": {
-      "version": "2.11.0",
-      "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/commander/-/commander-2.11.0.tgz",
-      "integrity": "sha1-FXFS/R56bI2YpbcVzzdt+SgARWM=",
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
       "dev": true
     },
     "concat-map": {
@@ -246,169 +222,23 @@
       "dev": true
     },
     "coveralls": {
-      "version": "2.13.3",
-      "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/coveralls/-/coveralls-2.13.3.tgz",
-      "integrity": "sha1-mtfCrlJ0F/Nh6LYmSD9I7pLdK8c=",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.2.tgz",
+      "integrity": "sha512-Tv0LKe/MkBOilH2v7WBiTBdudg2ChfGbdXafc/s330djpF3zKOmuehTeRwjXWc7pzfj9FrDUTA7tEx6Div8NFw==",
       "dev": true,
       "requires": {
-        "js-yaml": "3.6.1",
+        "growl": "1.10.5",
+        "js-yaml": "3.12.0",
         "lcov-parse": "0.0.10",
-        "log-driver": "1.2.5",
+        "log-driver": "1.2.7",
         "minimist": "1.2.0",
-        "request": "2.79.0"
+        "request": "2.88.0"
       },
       "dependencies": {
-        "assert-plus": {
-          "version": "0.2.0",
-          "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/assert-plus/-/assert-plus-0.2.0.tgz",
-          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
-          "dev": true
-        },
-        "aws-sign2": {
-          "version": "0.6.0",
-          "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/aws-sign2/-/aws-sign2-0.6.0.tgz",
-          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
-          "dev": true
-        },
-        "boom": {
-          "version": "2.10.1",
-          "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/boom/-/boom-2.10.1.tgz",
-          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-          "dev": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
-        },
-        "caseless": {
-          "version": "0.11.0",
-          "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/caseless/-/caseless-0.11.0.tgz",
-          "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
-          "dev": true
-        },
-        "cryptiles": {
-          "version": "2.0.5",
-          "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/cryptiles/-/cryptiles-2.0.5.tgz",
-          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-          "dev": true,
-          "requires": {
-            "boom": "2.10.1"
-          }
-        },
-        "esprima": {
-          "version": "2.7.3",
-          "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/esprima/-/esprima-2.7.3.tgz",
-          "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
-          "dev": true
-        },
-        "form-data": {
-          "version": "2.1.4",
-          "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/form-data/-/form-data-2.1.4.tgz",
-          "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-          "dev": true,
-          "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.17"
-          }
-        },
-        "har-validator": {
-          "version": "2.0.6",
-          "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/har-validator/-/har-validator-2.0.6.tgz",
-          "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
-          "dev": true,
-          "requires": {
-            "chalk": "1.1.3",
-            "commander": "2.11.0",
-            "is-my-json-valid": "2.17.1",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "hawk": {
-          "version": "3.1.3",
-          "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/hawk/-/hawk-3.1.3.tgz",
-          "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-          "dev": true,
-          "requires": {
-            "boom": "2.10.1",
-            "cryptiles": "2.0.5",
-            "hoek": "2.16.3",
-            "sntp": "1.0.9"
-          }
-        },
-        "hoek": {
-          "version": "2.16.3",
-          "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/hoek/-/hoek-2.16.3.tgz",
-          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-          "dev": true
-        },
-        "http-signature": {
-          "version": "1.1.1",
-          "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/http-signature/-/http-signature-1.1.1.tgz",
-          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-          "dev": true,
-          "requires": {
-            "assert-plus": "0.2.0",
-            "jsprim": "1.4.1",
-            "sshpk": "1.13.1"
-          }
-        },
-        "js-yaml": {
-          "version": "3.6.1",
-          "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/js-yaml/-/js-yaml-3.6.1.tgz",
-          "integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=",
-          "dev": true,
-          "requires": {
-            "argparse": "1.0.9",
-            "esprima": "2.7.3"
-          }
-        },
-        "qs": {
-          "version": "6.3.2",
-          "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/qs/-/qs-6.3.2.tgz",
-          "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw=",
-          "dev": true
-        },
-        "request": {
-          "version": "2.79.0",
-          "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/request/-/request-2.79.0.tgz",
-          "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
-          "dev": true,
-          "requires": {
-            "aws-sign2": "0.6.0",
-            "aws4": "1.6.0",
-            "caseless": "0.11.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.1.4",
-            "har-validator": "2.0.6",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.17",
-            "oauth-sign": "0.8.2",
-            "qs": "6.3.2",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.3",
-            "tunnel-agent": "0.4.3",
-            "uuid": "3.3.2"
-          }
-        },
-        "sntp": {
-          "version": "1.0.9",
-          "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/sntp/-/sntp-1.0.9.tgz",
-          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-          "dev": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
-        },
-        "tunnel-agent": {
-          "version": "0.4.3",
-          "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-          "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
+        "log-driver": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.7.tgz",
+          "integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==",
           "dev": true
         }
       }
@@ -459,12 +289,6 @@
         "jsbn": "0.1.1"
       }
     },
-    "escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
-    },
     "escodegen": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
@@ -496,16 +320,22 @@
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
-    "extend": {
-      "version": "3.0.1",
-      "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/extend/-/extend-3.0.1.tgz",
-      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
-      "dev": true
-    },
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true
+    },
+    "fast-deep-equal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
       "dev": true
     },
     "fast-levenshtein": {
@@ -520,19 +350,26 @@
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
       "dev": true
     },
-    "generate-function": {
-      "version": "2.0.0",
-      "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/generate-function/-/generate-function-2.0.0.tgz",
-      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
-      "dev": true
-    },
-    "generate-object-property": {
-      "version": "1.2.0",
-      "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/generate-object-property/-/generate-object-property-1.2.0.tgz",
-      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+    "form-data": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+      "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
       "dev": true,
       "requires": {
-        "is-property": "1.0.2"
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.6",
+        "mime-types": "2.1.17"
+      },
+      "dependencies": {
+        "combined-stream": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+          "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+          "dev": true,
+          "requires": {
+            "delayed-stream": "1.0.0"
+          }
+        }
       }
     },
     "getpass": {
@@ -556,6 +393,12 @@
         "once": "1.4.0",
         "path-is-absolute": "1.0.1"
       }
+    },
+    "growl": {
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+      "dev": true
     },
     "handlebars": {
       "version": "4.0.11",
@@ -586,13 +429,20 @@
         }
       }
     },
-    "has-ansi": {
+    "har-schema": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "dev": true
+    },
+    "har-validator": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
+      "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ajv": "5.5.2",
+        "har-schema": "2.0.0"
       }
     },
     "has-flag": {
@@ -600,6 +450,17 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
       "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
       "dev": true
+    },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.13.1"
+      }
     },
     "inflight": {
       "version": "1.0.6",
@@ -621,24 +482,6 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
-    },
-    "is-my-json-valid": {
-      "version": "2.17.1",
-      "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/is-my-json-valid/-/is-my-json-valid-2.17.1.tgz",
-      "integrity": "sha1-PamJFKcKIvCoVj7xURokbG/FVHE=",
-      "dev": true,
-      "requires": {
-        "generate-function": "2.0.0",
-        "generate-object-property": "1.2.0",
-        "jsonpointer": "4.0.1",
-        "xtend": "4.0.1"
-      }
-    },
-    "is-property": {
-      "version": "1.0.2",
-      "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/is-property/-/is-property-1.0.2.tgz",
-      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
       "dev": true
     },
     "is-typedarray": {
@@ -744,16 +587,16 @@
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
       "dev": true
     },
+    "json-schema-traverse": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+      "dev": true
+    },
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-      "dev": true
-    },
-    "jsonpointer": {
-      "version": "4.0.1",
-      "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/jsonpointer/-/jsonpointer-4.0.1.tgz",
-      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
       "dev": true
     },
     "jsprim": {
@@ -814,12 +657,6 @@
       "version": "4.4.2",
       "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
-    },
-    "log-driver": {
-      "version": "1.2.5",
-      "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/log-driver/-/log-driver-1.2.5.tgz",
-      "integrity": "sha1-euTsJXMC/XkNVXyxDJcQDYV7AFY=",
-      "dev": true
     },
     "longest": {
       "version": "1.0.1",
@@ -1064,12 +901,6 @@
         "abbrev": "1.0.9"
       }
     },
-    "oauth-sign": {
-      "version": "0.8.2",
-      "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/oauth-sign/-/oauth-sign-0.8.2.tgz",
-      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
-      "dev": true
-    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -1123,20 +954,11 @@
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
-    "pinkie": {
-      "version": "2.0.4",
-      "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "dev": true
-    },
-    "pinkie-promise": {
-      "version": "2.0.1",
-      "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "dev": true,
-      "requires": {
-        "pinkie": "2.0.4"
-      }
     },
     "prelude-ls": {
       "version": "1.1.2",
@@ -1144,10 +966,22 @@
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
+    "psl": {
+      "version": "1.1.29",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
+      "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==",
+      "dev": true
+    },
     "punycode": {
       "version": "1.4.1",
       "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/punycode/-/punycode-1.4.1.tgz",
       "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+      "dev": true
+    },
+    "qs": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true
     },
     "regexp-clone": {
@@ -1160,6 +994,88 @@
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
       "dev": true
+    },
+    "request": {
+      "version": "2.88.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+      "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+      "dev": true,
+      "requires": {
+        "aws-sign2": "0.7.0",
+        "aws4": "1.8.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.6",
+        "extend": "3.0.2",
+        "forever-agent": "0.6.1",
+        "form-data": "2.3.2",
+        "har-validator": "5.1.0",
+        "http-signature": "1.2.0",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.20",
+        "oauth-sign": "0.9.0",
+        "performance-now": "2.1.0",
+        "qs": "6.5.2",
+        "safe-buffer": "5.1.2",
+        "tough-cookie": "2.4.3",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.3.2"
+      },
+      "dependencies": {
+        "aws4": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+          "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
+          "dev": true
+        },
+        "combined-stream": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+          "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+          "dev": true,
+          "requires": {
+            "delayed-stream": "1.0.0"
+          }
+        },
+        "extend": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+          "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+          "dev": true
+        },
+        "mime-db": {
+          "version": "1.36.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.36.0.tgz",
+          "integrity": "sha512-L+xvyD9MkoYMXb1jAmzI/lWYAxAMCPvIBSWur0PZ5nOf5euahRLVqH//FKW9mWp2lkqUgYiXPgkzfMUFi4zVDw==",
+          "dev": true
+        },
+        "mime-types": {
+          "version": "2.1.20",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.20.tgz",
+          "integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
+          "dev": true,
+          "requires": {
+            "mime-db": "1.36.0"
+          }
+        },
+        "oauth-sign": {
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+          "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+          "dev": true
+        },
+        "tough-cookie": {
+          "version": "2.4.3",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+          "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+          "dev": true,
+          "requires": {
+            "psl": "1.1.29",
+            "punycode": "1.4.1"
+          }
+        }
+      }
     },
     "require_optional": {
       "version": "1.0.1",
@@ -1190,6 +1106,12 @@
       "requires": {
         "align-text": "0.1.4"
       }
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
     },
     "semver": {
       "version": "5.5.0",
@@ -1239,21 +1161,6 @@
         "tweetnacl": "0.14.5"
       }
     },
-    "stringstream": {
-      "version": "0.0.5",
-      "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/stringstream/-/stringstream-0.0.5.tgz",
-      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
-      "dev": true
-    },
-    "strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "dev": true,
-      "requires": {
-        "ansi-regex": "2.1.1"
-      }
-    },
     "supports-color": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
@@ -1269,13 +1176,13 @@
       "integrity": "sha1-TcGeZk38y+Jb2NtQiwDG2hWCVdE=",
       "dev": true
     },
-    "tough-cookie": {
-      "version": "2.3.3",
-      "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/tough-cookie/-/tough-cookie-2.3.3.tgz",
-      "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "dev": true,
       "requires": {
-        "punycode": "1.4.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "tweetnacl": {
@@ -1370,12 +1277,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
-    },
-    "xtend": {
-      "version": "4.0.1",
-      "resolved": "https://artifactory.mia.ucloud.int/artifactory/api/npm/npm/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
       "dev": true
     },
     "yargs": {

--- a/package.json
+++ b/package.json
@@ -27,10 +27,10 @@
     "binary"
   ],
   "devDependencies": {
-    "chai": "^3.2.0",
+    "chai": "^4.1.2",
     "coveralls": "^3.0.2",
     "istanbul": "^0.4.5",
-    "mocha": "^2.3.2",
+    "mocha": "^5.2.0",
     "uuid": "^3.3.2"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   ],
   "devDependencies": {
     "chai": "^3.2.0",
-    "coveralls": "^2.11.4",
+    "coveralls": "^3.0.2",
     "istanbul": "^0.4.5",
     "mocha": "^2.3.2",
     "uuid": "^3.3.2"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "bson": "^1.0.4",
     "debug": "^3.1.0",
     "mongoose": "^5.0.3",
-    "node-uuid": "^1.4.8"
+    "uuid-parse": "^1.0.0"
   },
   "keywords": [
     "mongoose",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "license": "ISC",
   "dependencies": {
-    "bson": "^1.0.4",
+    "bson": "^3.0.2",
     "debug": "^3.1.0",
     "mongoose": "^5.0.3",
     "uuid-parse": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -29,8 +29,9 @@
   "devDependencies": {
     "chai": "^3.2.0",
     "coveralls": "^2.11.4",
-    "istanbul": "^0.3.20",
-    "mocha": "^2.3.2"
+    "istanbul": "^0.4.5",
+    "mocha": "^2.3.2",
+    "uuid": "^3.3.2"
   },
   "engines": {
     "node": ">=6.4.0"

--- a/test/index.js
+++ b/test/index.js
@@ -19,11 +19,11 @@ var Product = mongoose.model('Product', ProductSchema);
 
 describe('mongoose-uuid', function(){
   before(function() {
-    return mongoose.connect('mongodb://localhost:27017/mongoose-uuid-test')
+    return mongoose.connect('mongodb://localhost:27017/mongoose-uuid-test', { useNewUrlParser: true })
   })
 
   after(function(cb) {
-    Product.remove({}, function() {
+    Product.deleteMany({}, function() {
       mongoose.disconnect(cb);
     });
   });
@@ -108,8 +108,8 @@ describe('mongoose-uuid', function(){
     })
 
     after(function(cb) {
-      Pet.remove(function() {
-        Photo.remove({}, cb);
+      Pet.deleteMany(function() {
+        Photo.deleteMany({}, cb);
       })
 
     });
@@ -138,7 +138,7 @@ describe('mongoose-uuid', function(){
     var Boat = mongoose.model('Boat', BoatSchema);
 
     afterEach(function(cb) {
-      Boat.remove(cb);
+      Boat.deleteMany({}, cb);
     });
 
     it('should get with no value', function() {

--- a/test/index.js
+++ b/test/index.js
@@ -1,4 +1,4 @@
-var uuid = require('node-uuid');
+var uuidv4 = require('uuid/v4');
 var mongoose = require('mongoose');
 var bson = require('bson');
 var should = require('chai').should();
@@ -8,7 +8,7 @@ require('../index')(mongoose);
 var UUID = mongoose.Types.UUID;
 
 var ProductSchema = Schema({
-  _id: { type: UUID, default: uuid.v4 },
+  _id: { type: UUID, default: uuidv4 },
   name: String
 }, { id: false });
 
@@ -73,7 +73,7 @@ describe('mongoose-uuid', function(){
 
   describe('query population', function() {
     var PetSchema = Schema({
-      _id: { type: UUID, default: uuid.v4 },
+      _id: { type: UUID, default: uuidv4 },
       name: String,
     }, { id: false });
 
@@ -83,7 +83,7 @@ describe('mongoose-uuid', function(){
     var Pet = mongoose.model('Pet', PetSchema);
 
     var PhotoSchema = Schema({
-      _id: { type: UUID, default: uuid.v4 },
+      _id: { type: UUID, default: uuidv4 },
       filename: String,
       pet: { type: UUID, ref: 'Pet', required: true }
     }, { id: false });
@@ -124,11 +124,11 @@ describe('mongoose-uuid', function(){
   });
 
   describe('other scenarios', function() {
-    var uuidBuffer = new mongoose.Types.Buffer(uuid.v4());
+    var uuidBuffer = new mongoose.Types.Buffer(uuidv4());
     uuidBuffer.subtype(bson.Binary.SUBTYPE_UUID);
 
     var BoatSchema = Schema({
-      _id: { type: UUID, default: uuid.v4 },
+      _id: { type: UUID, default: uuidv4 },
       dingy: { type: UUID, ref: 'Boat' },
       name: String,
     }, { id: false });

--- a/test/index.js
+++ b/test/index.js
@@ -3,7 +3,8 @@ var mongoose = require('mongoose');
 var bson = require('bson');
 var should = require('chai').should();
 var Schema = mongoose.Schema;
-// Will add the UUID type to the Mongoose Schema types
+
+// adds the UUID type to the Mongoose Schema types
 require('../index')(mongoose);
 var UUID = mongoose.Types.UUID;
 
@@ -17,7 +18,7 @@ ProductSchema.set('toJSON', {getters: true});
 
 var Product = mongoose.model('Product', ProductSchema);
 
-describe('mongoose-uuid', function(){
+describe('mongoose-uuid', function() {
   before(function() {
     return mongoose.connect('mongodb://localhost:27017/mongoose-uuid-test', { useNewUrlParser: true })
   })
@@ -28,20 +29,40 @@ describe('mongoose-uuid', function(){
     });
   });
 
-  it('should cast uuid strings to binary', function(){
+  it('should cast uuid strings to binary', function() {
     var product = new Product({
       _id: '7c401d91-3852-4818-985d-7e7b79f771c3',
       name: 'Some product'
     });
+
     (product._doc._id instanceof mongoose.Types.Buffer.Binary).should.equal(true);
   });
 
-  it('should convert back to text with toObject()', function(){
+  it('should cast null to null', function() {
+    var product = new Product({
+      _id: null,
+      name: 'Some product'
+    });
+
+    (product._doc._id == null).should.equal(true);
+  });
+
+  it('should not throw when given anything other than a Buffer or String', function() {
+    var product = new Product({
+      _id: 300,
+      name: 'Some product'
+    });
+
+    (product._doc._id == null).should.equal(false);
+  });
+
+  it('should convert back to text with toObject()', function() {
     var product = new Product({
       _id: '7c401d91-3852-4818-985d-7e7b79f771c3',
       name: 'Some product'
     });
     var productObject = product.toObject();
+
     (productObject._id).should.equal('7c401d91-3852-4818-985d-7e7b79f771c3');
   });
 
@@ -50,14 +71,18 @@ describe('mongoose-uuid', function(){
       _id: '7c401d91-3852-4818-985d-7e7b79f771c3',
       name: 'Some product'
     });
+
     product.save(cb);
   });
 
   it('should be found correctly with .find()', function(cb) {
     Product.findOne({_id: '7c401d91-3852-4818-985d-7e7b79f771c3'}, function(err, product) {
       (product).should.not.be.null;
+
       var productObject = product.toObject();
+
       (productObject._id).should.equal('7c401d91-3852-4818-985d-7e7b79f771c3');
+
       cb(err);
     });
   });
@@ -65,8 +90,11 @@ describe('mongoose-uuid', function(){
   it('should be found correctly with .findById()', function(cb) {
     Product.findById('7c401d91-3852-4818-985d-7e7b79f771c3', function(err, product) {
       (product).should.not.be.null;
+
       var productObject = product.toObject();
+
       (productObject._id).should.equal('7c401d91-3852-4818-985d-7e7b79f771c3');
+
       cb(err);
     });
   });
@@ -97,11 +125,13 @@ describe('mongoose-uuid', function(){
       var pet = new Pet({
         name: 'Sammy'
       });
+
       var photo = new Photo({
         _id: '7c401d91-3852-4818-985d-7e7b79f771c2',
         filename: 'photo.jpg',
         pet: pet._id
       });
+
       pet.save(function() {
         photo.save(cb);
       })
@@ -111,22 +141,19 @@ describe('mongoose-uuid', function(){
       Pet.deleteMany(function() {
         Photo.deleteMany({}, cb);
       })
-
     });
 
     it('should work', function(cb) {
       Photo.findById('7c401d91-3852-4818-985d-7e7b79f771c2').populate('pet').exec(function(err, photo) {
         (photo.pet).should.exist;
         (photo.pet.name).should.equal('Sammy');
+
         cb(err);
       });
     });
   });
 
   describe('other scenarios', function() {
-    var uuidBuffer = new mongoose.Types.Buffer(uuidv4());
-    uuidBuffer.subtype(bson.Binary.SUBTYPE_UUID);
-
     var BoatSchema = Schema({
       _id: { type: UUID, default: uuidv4 },
       dingy: { type: UUID, ref: 'Boat' },
@@ -145,6 +172,7 @@ describe('mongoose-uuid', function(){
       var boat = new Boat({
         name: 'Sunshine'
       });
+
       (undefined === boat.dingy).should.be.true;
     });
 
@@ -159,15 +187,18 @@ describe('mongoose-uuid', function(){
         name: 'Sunshine',
         dingy: ripples._id
       });
+
       splash.save(function() {
         ripples.save(function() {
           sunshine.save(function() {
             Boat.findOne({name: 'Sunshine'}).populate('dingy').exec(function(err, boat) {
               (boat.dingy._id).should.equal(ripples._id);
+
               boat.dingy = splash._id;
               boat.save(function() {
                 Boat.findOne({name: 'Sunshine'}).populate('dingy').exec(function(err, boat2) {
                   (boat2.dingy._id).should.equal(splash._id);
+
                   cb();
                 })
               })


### PR DESCRIPTION
This update removes the usage of `node-uuid` as it has been deprecated in favor of `uuid`. However, `uuid` no longer has the method `parse` that is used by this library. There has been a re-publish of `parse` using a fork of the original `node-uuid` that strips out everything other than the `parse` and `unparse` methods called `uuid-parse`.

uuid generation was still being used for testing purposes, so `uuid` has been added as a devDependency and related references have been updated to the newer API.

There was also a security vulnerability present in the older version of `istanbul` being used by this project. Updating `istanbul` has patched this without any apparent regressions.

Closes #13.